### PR TITLE
Adding a timeout before submitting after opening

### DIFF
--- a/ui/main.js
+++ b/ui/main.js
@@ -1,12 +1,16 @@
 let RowsData = [];
 let Rows = [];
 let savedHeader = "";
+let canSubmit = false
 
 const OpenKeyboard = (data) => {
     $(`.main-wrapper`).fadeIn(0)
     $(`.background`).fadeIn(0)
     SetHeader(data.header ? data.header : "")
     AddRow(data.rows)
+    setTimeout(() => {
+		canSubmit = true;
+	}, 500);
 }
 
 const SetHeader = (header) => {
@@ -22,6 +26,7 @@ const CloseKeyboard = () => {
     RowsData = [];
     Rows = [];
     savedHeader = "";
+    canSubmit = false
 };
 
 const AddRow = (data) => {
@@ -67,6 +72,7 @@ const CancelKeyboard = () => {
         $(Rows[i]).remove();
     }
     $.post(`https://nh-keyboard/cancel`)
+    canSubmit = false
 }
 
 window.addEventListener("message", (evt) => {
@@ -89,7 +95,9 @@ window.addEventListener("keyup", (ev) => {
     if (ev.which == 27) {
         CancelKeyboard();
     } else if (ev.which == 13) {
-        SubmitData()
+        if(canSubmit){
+            SubmitData()
+        }
     }
 })
 


### PR DESCRIPTION
This solves the problem when opening the input menu after pressing enter immediately.

My use case was registering a command and typing the command and press enter in the chat, it will immediately close. Another one is when i open it using a menu UI like menuv after selecting a button (Pressing enter) it should appear, but it closes immediately since it detects the keyup event after selecting the button.